### PR TITLE
move method next to msg id to keep same as the response log

### DIFF
--- a/cmd/api-firewall/internal/handlers/openapi.go
+++ b/cmd/api-firewall/internal/handlers/openapi.go
@@ -106,8 +106,8 @@ func getValidationHeader(ctx *fasthttp.RequestCtx, err error) *string {
 func (s *openapiWaf) openapiWafHandler(ctx *fasthttp.RequestCtx) error {
 	s.logger.Debugf("New Request: #%016X : %s -> %s %s (%s)",
 		ctx.ID(),
-		ctx.RemoteAddr(),
-		ctx.Request.Header.Method(), ctx.Path(),
+		ctx.Request.Header.Method(),
+		ctx.RemoteAddr(), ctx.Path(),
 		time.Since(ctx.Time()),
 	)
 


### PR DESCRIPTION
response sequence for log

                        logger.Infof("(%d) : #%016X : %s %s -> %s (%s)",
                                ctx.Response.StatusCode(),
                                ctx.ID(),
                                ctx.Request.Header.Method(), ctx.Path(),
                                ctx.RemoteAddr(), time.Since(start),
                        )